### PR TITLE
readonly and required attributes bug and validation CSS

### DIFF
--- a/src/ng2-datetime/ng2-datetime.ts
+++ b/src/ng2-datetime/ng2-datetime.ts
@@ -33,7 +33,8 @@ import { TimepickerEvent } from './timepicker-event-interface';
         </div>
         <button *ngIf="hasClearButton" type="button" (click)="clearModels()">Clear</button>
     </div>
-   `
+   `,
+   styles: ['.invalidInput { border: solid 1.5px red; }']
 })
 
 export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestroy, OnChanges {
@@ -160,6 +161,7 @@ export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestro
                     }
 
                     this.date = newDate;
+                    this.timeInputClasses = null;
                     this.dateChange.emit(newDate);
                 });
         } else if (this.datepickerOptions === false) {
@@ -191,6 +193,7 @@ export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestro
 
                     this.date.setHours(hours);
                     this.date.setMinutes(e.time.minutes);
+                    this.dateInputClasses = null;
                     this.dateChange.emit(this.date);
                 });
         } else if (this.timepickerOptions === false) {

--- a/src/ng2-datetime/ng2-datetime.ts
+++ b/src/ng2-datetime/ng2-datetime.ts
@@ -11,23 +11,25 @@ import { TimepickerEvent } from './timepicker-event-interface';
     <div class="form-inline">
         <div id="{{idDatePicker}}" class="input-group date">
             <input type="text" class="form-control"
-                   [attr.readonly]="readonly"
-                   [attr.required]="required"
+                   [attr.readonly]="readonly ? true : null"
+                   [attr.required]="required ? true : null"
+                   [ngClass]="dateInputClasses"
                    [attr.placeholder]="datepickerOptions.placeholder || 'Choose date'"
                    [(ngModel)]="dateModel"
                    (keyup)="checkEmptyValue($event)"/>
             <div class="input-group-addon">
-                <span [ngClass]="datepickerOptions.icon || 'glyphicon glyphicon-th'"></span>
+                <span [ngClass]="datepickerOptions.icon || 'fa fa-calendar'"></span>
             </div>
         </div>
         <div class="input-group bootstrap-timepicker timepicker">
             <input id="{{idTimePicker}}" type="text" class="form-control input-small" 
-                   [attr.readonly]="readonly"
-                   [attr.required]="required"
+                   [attr.readonly]="readonly ? true : null"
+                   [attr.required]="required ? true : null"
+                   [ngClass]="timeInputClasses"
                    [attr.placeholder]="timepickerOptions.placeholder || 'Set time'"
                    [(ngModel)]="timeModel"
                    (keyup)="checkEmptyValue($event)">
-            <span class="input-group-addon"><i [ngClass]="timepickerOptions.icon || 'glyphicon glyphicon-time'"></i></span>
+            <span class="input-group-addon"><i [ngClass]="timepickerOptions.icon || 'fa fa-clock-o'"></i></span>
         </div>
         <button *ngIf="hasClearButton" type="button" (click)="clearModels()">Clear</button>
     </div>
@@ -41,6 +43,8 @@ export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestro
     @Input('hasClearButton') hasClearButton: boolean = false;
     @Input() readonly: boolean = null;
     @Input() required: boolean = null;
+    @Input() timeInputClasses: Object = {};
+    @Input() dateInputClasses: Object = {};
 
     date: Date; // ngModel
     dateModel: string;

--- a/src/ng2-datetime/ng2-datetime.ts
+++ b/src/ng2-datetime/ng2-datetime.ts
@@ -161,7 +161,7 @@ export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestro
                     }
 
                     this.date = newDate;
-                    this.timeInputClasses = null;
+                    this.dateInputClasses = null;
                     this.dateChange.emit(newDate);
                 });
         } else if (this.datepickerOptions === false) {
@@ -193,7 +193,7 @@ export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestro
 
                     this.date.setHours(hours);
                     this.date.setMinutes(e.time.minutes);
-                    this.dateInputClasses = null;
+                    this.timeInputClasses = null;
                     this.dateChange.emit(this.date);
                 });
         } else if (this.timepickerOptions === false) {


### PR DESCRIPTION
fixed the bug on readonly and required attributes not work properly while pass a false value;
used font-awesome icons instead bootstrap built-in icon set since bootstrap 4 have removed icon set;
allow css error effect for date and time input boxes while there is a validation error