### PR TITLE
Add support for tabindex, pass-through to child inputs.

### DIFF
--- a/src/ng2-datetime/ng2-datetime.ts
+++ b/src/ng2-datetime/ng2-datetime.ts
@@ -1,6 +1,6 @@
 import {
     Component, Output, Input, EventEmitter, HostListener, AfterViewInit, OnDestroy,
-    SimpleChanges, OnChanges
+    SimpleChanges, OnChanges, HostBinding
 } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
 import { ITimepickerEvent } from './ITimepickerEvent';
@@ -14,6 +14,7 @@ import { ITimepickerEvent } from './ITimepickerEvent';
                        [attr.readonly]="readonly"
                        [attr.required]="required"
                        [attr.placeholder]="datepickerOptions.placeholder || 'Choose date'"
+                       [attr.tabindex]="tabindex"
                        [(ngModel)]="dateModel"
                        (keyup)="checkEmptyValue($event)"/>
                 <div [hidden]="datepickerOptions.hideIcon || datepickerOptions === false || false"
@@ -27,6 +28,7 @@ import { ITimepickerEvent } from './ITimepickerEvent';
                        [attr.readonly]="readonly"
                        [attr.required]="required"
                        [attr.placeholder]="timepickerOptions.placeholder || 'Set time'"
+                       [attr.tabindex]="tabindex"
                        [(ngModel)]="timeModel"
                        (focus)="showTimepicker()"
                        (keyup)="checkEmptyValue($event)">
@@ -49,6 +51,7 @@ export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestro
     @Input('hasClearButton') hasClearButton: boolean = false;
     @Input() readonly: boolean = null;
     @Input() required: boolean = null;
+    @Input() tabindex: string;
 
     date: Date; // ngModel
     dateModel: string;
@@ -65,6 +68,11 @@ export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestro
     onChange = (_: any) => {
     }
     onTouched = () => {
+    }
+
+    @HostBinding('attr.tabindex')
+    get tabindexAttr(): string {
+        return this.tabindex === undefined ? '-1' : undefined;
     }
 
     constructor(ngControl: NgControl) {


### PR DESCRIPTION
Currently, when you set the tabindex on the datetime element, and then tab to
it, only the container element is focussed. This fix takes the specified 
tabindex, unsets it on the container element and then passes it through to the
datepicker and timepicker input elements. This allows you to tab directly to
the datepicker and timepicker inputs.