### PR TITLE
Move value accessor declaration to component annotation.

### DIFF
--- a/config/karma-test-shim.js
+++ b/config/karma-test-shim.js
@@ -11,6 +11,10 @@ require('zone.js/dist/jasmine-patch');
 require('zone.js/dist/async-test');
 require('zone.js/dist/fake-async-test');
 
+window.jQuery = window.$ = require('jquery');
+require('bootstrap-datepicker');
+require('bootstrap-timepicker');
+
 var appContext = require.context('../src', true, /\.spec\.ts/);
 
 appContext.keys().forEach(appContext);

--- a/src/ng2-datetime/ng2-datetime.spec.ts
+++ b/src/ng2-datetime/ng2-datetime.spec.ts
@@ -1,0 +1,78 @@
+import { Component, Type } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
+import { NKDatetimeModule } from './ng2-datetime.module';
+import { NKDatetime } from './ng2-datetime';
+
+describe('ng2-datetime', () => {
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [FormsModule, NKDatetimeModule],
+            declarations: [DatePickerComponent]
+        });
+    });
+
+    it('should instantiate', () => {
+        const component = TestBed.createComponent(NKDatetime).componentInstance;
+        expect(component).not.toBeNull();
+        expect(component instanceof NKDatetime).toEqual(true);
+    });
+
+    describe('datepicker', () => {
+        it('should update ngModel when datepicker value changes', fakeAsync(() => {
+            const fixture = TestBed.createComponent(DatePickerComponent);
+            const component = getComponent(fixture, NKDatetime);
+
+            fixture.componentInstance.date = null;
+
+            tickAndDetect(fixture);
+
+            component.datepicker.datepicker('setDate', new Date(2011, 2, 5));
+
+            tickAndDetect(fixture);
+
+            expect(fixture.componentInstance.date).toEqual(new Date(2011, 2, 5));
+        }));
+    });
+
+    describe('timepicker', () => {
+        it('should update ngModel when timepicker value changes', fakeAsync(() => {
+            const fixture = TestBed.createComponent(DatePickerComponent);
+            const component = getComponent(fixture, NKDatetime);
+
+            fixture.componentInstance.date = new Date(2011, 2, 5, 0, 0);
+
+            tickAndDetect(fixture);
+            tickAndDetect(fixture);
+
+            component.timepicker.timepicker('setTime', '12:45 AM');
+
+            tickAndDetect(fixture);
+
+            expect(fixture.componentInstance.date).toEqual(new Date(2011, 2, 5, 0, 45));
+        }));
+    });
+});
+
+function getComponent<T>(fixture: ComponentFixture<any>, type: Type<T>): T {
+    // tick for each component in the component tree
+    tickAndDetect(fixture);
+    tickAndDetect(fixture);
+    return fixture.debugElement.query(By.directive(type)).componentInstance;
+}
+
+function tickAndDetect(fixture: ComponentFixture<any>) {
+    tick();
+    fixture.detectChanges();
+}
+
+@Component({
+    template: `
+        <datetime [(ngModel)]="date"></datetime>
+    `
+})
+class DatePickerComponent {
+    date: Date;
+}

--- a/src/ng2-datetime/ng2-datetime.ts
+++ b/src/ng2-datetime/ng2-datetime.ts
@@ -1,12 +1,19 @@
 import {
     Component, Output, Input, EventEmitter, HostListener, AfterViewInit, OnDestroy,
-    SimpleChanges, OnChanges, HostBinding
+    SimpleChanges, OnChanges, HostBinding, forwardRef
 } from '@angular/core';
-import { ControlValueAccessor, NgControl } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ITimepickerEvent } from './ITimepickerEvent';
+
+const CUSTOM_ACCESSOR = {
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => NKDatetime),
+    multi: true
+};
 
 @Component({
     selector: 'datetime',
+    providers: [CUSTOM_ACCESSOR],
     template: `
         <div class="form-inline ng2-datetime">
             <div [ngClass]="{ 'form-group': true, 'input-group': !datepickerOptions.hideIcon, 'date': true }">
@@ -76,10 +83,6 @@ export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestro
     @HostBinding('attr.tabindex')
     get tabindexAttr(): string {
         return this.tabindex === undefined ? '-1' : undefined;
-    }
-
-    constructor(ngControl: NgControl) {
-        ngControl.valueAccessor = this; // override valueAccessor
     }
 
     ngAfterViewInit() {


### PR DESCRIPTION
Injecting NgControl makes the control harder to test. The value accessor can
be set in the component annotation instead. This fix also includes tests to 
ensure the value accessor is working properly.