### PR TITLE
Improved installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ Datetime picker (plugins wrapper) for Angular.
 - [Bootstrap-timepicker __(JS+CSS)__](http://jdewit.github.io/bootstrap-timepicker/)
 
 ## Installation
-`npm install --save ng2-datetime`
+```npm install --save ng2-datetime```
+
+If your project does not use jQuery yet, add the required jQuery packages as well:
+```npm install jquery --save
+npm install @types/jquery --save
+```
 
 ## Usage
 1. import some way or another the required dependencies in the following order:


### PR DESCRIPTION
Instructions for jQuery installation were missing. Without jQuery, the issue described here occurs: http://stackoverflow.com/questions/40994719/cannot-find-name-jquery-in-angular2