### PR TITLE
Keep field clean on Init

### DIFF
--- a/src/ng2-datetime/ng2-datetime.ts
+++ b/src/ng2-datetime/ng2-datetime.ts
@@ -129,7 +129,7 @@ export class NKDatetime implements ControlValueAccessor, AfterViewInit, OnDestro
                 this.updateModel(this.date);
             }, 0);
         } else {
-            this.clearModels();
+            // this.clearModels();
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
— Remove the `clearModels()` call from the `writeValue` method of the component. Calling `clearModels` makes the field dirty by default and set's the model's value to `null`. This sucks.
