### PR TITLE
Updated to Fix issue for manual date entry.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "bootstrap": ">=3.0.0",
-    "bootstrap-datepicker": "1.7.0-RC1",
+    "bootstrap-datepicker": "1.8.0",
     "bootstrap-timepicker": "^0.5.2",
     "jquery": ">=2.2.1"
   },


### PR DESCRIPTION
Manually entering a date into the input field, ngModel would not update.  This uses the new bootstrap-datepicker that addresses the issues.